### PR TITLE
specify influxdb version when image taged as latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM ubuntu:trusty
+FROM tutum/curl:trusty
 MAINTAINER Feng Honglin <hfeng@tutum.co>
- 
-# Install InfluxDB
-RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends curl ca-certificates
 
+# Install InfluxDB
 ENV INFLUXDB_VERSION 0.8.2
 RUN curl -s -o /tmp/influxdb_latest_amd64.deb https://s3.amazonaws.com/influxdb/influxdb_${INFLUXDB_VERSION}_amd64.deb && \
   dpkg -i /tmp/influxdb_latest_amd64.deb && \


### PR DESCRIPTION
When the docker image built withthe _latest_ tag, there is no way to tell which version
is installed in it.

The other problem is, that you have to trigger the registry, when you want to have the latest
version, as the url `https://s3.amazonaws.com/influxdb/influxdb_latest_amd64.deb` never changes.
# latest tag

I would suggest to use an ENV variable. This way:
- just by reading the Dockerfile makes clear the version number
- When you want to update `latest`, pushing a `ENV INFLUXDB_VERSION 0.8.X` change to github, automatically triggers the registry to rebuild it.
# versioned tags

If you want to keep older versions available, you might create tags/branches in github, and appropriate docker tags at the [registry](https://registry.hub.docker.com/u/tutum/influxdb/tags/manage/)
