### PR TITLE
eval SEEDS when it contains ENV reference

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,7 @@ if [ -n "${FORCE_HOSTNAME}" ]; then
 fi
 
 if [ -n "${SEEDS}" ]; then
-    SEEDS=$(echo $SEEDS | grep '^\".*\"$' || echo "\""$SEEDS"\"" | sed -e 's/, */", "/g')
+    SEEDS=$(eval SEEDS=$SEEDS ; echo $SEEDS | grep '^\".*\"$' || echo "\""$SEEDS"\"" | sed -e 's/, */", "/g')
     /usr/bin/perl -p -i -e "s/^# seed-servers.*$/seed-servers = [${SEEDS}]/g" ${CONFIG_FILE}
 fi
 


### PR DESCRIPTION
In case we link containers using environment reference, `SEEDS` variable needs to eval that reference prior to escaping.
This usually happens when the orchestration for docker uses escaping for env variables (like Kubernetes does)

e.g.

`docker run -e SEEDS="\${INFLUXDB_MASTER_HOST}:\${INFLUXDB_MASTER_PORT}" tutum/influxdb`
before the patch: `SEEDS=${INFLUXDB_MASTER_HOST}:${INFLUXDB_MASTER_PORT}` as raw text
after the patch: `SEEDS=10.2.3.10:8090`
