### PR TITLE
Added Support for Graphite

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -34,8 +34,8 @@ read-timeout = "5s"
   [input_plugins.graphite]
   enabled = false
   # port = 2003
-  # database = ""  # store graphite data in this database
-  # udp_enabled = true # enable udp interface on the same port as the tcp interface
+  # database = ""
+  # udp_enabled = true
 
   [input_plugins.udp]
   enabled = false

--- a/run.sh
+++ b/run.sh
@@ -38,6 +38,15 @@ if [ "${SSL_SUPPORT}" == "**False**" ]; then
     unset SSL_SUPPORT
 fi
 
+# Add Graphite support
+if [ -n "${GRAPHITE_DB}" ]; then
+    sed -i -r -e "/^\s+\[input_plugins.graphite\]/, /^$/ { s/false/true/; s/#//g; s/\"\"/\"${GRAPHITE_DB}\"/g; }" ${CONFIG_FILE}
+fi
+
+if [ -n "${GRAPHITE_PORT}" ]; then
+    sed -i -r -e "/^\s+\[input_plugins.graphite\]/, /^$/ { s/2003/${GRAPHITE_PORT}/; }" ${CONFIG_FILE}
+fi
+
 # Add UDP support
 if [ -n "${UDP_DB}" ]; then
     sed -i -r -e "/^\s+\[input_plugins.udp\]/, /^$/ { s/false/true/; s/#//g; s/\"\"/\"${UDP_DB}\"/g; }" ${CONFIG_FILE}


### PR DESCRIPTION
Allow the image to enable the Graphite plugin  by providing `GRAPHITE_DB` and `GRAPHITE_PORT` environment variables.